### PR TITLE
Status bar disappearing on Whistle hotfix.

### DIFF
--- a/Source/WhistleFactory.swift
+++ b/Source/WhistleFactory.swift
@@ -69,7 +69,6 @@ public class WhistleFactory: UIViewController {
   public func setupFrames() {
     titleLabel.sizeToFit()
 
-    whistleWindow.rootViewController = self
     whistleWindow.frame = CGRect(x: 0, y: 0, width: UIScreen.mainScreen().bounds.width,
       height: Dimensions.height)
     view.frame = whistleWindow.bounds


### PR DESCRIPTION
 I don't know why, but removing `whistleWindow.rootViewController = self` from `setupFrames()` fixes #25. It seems that it doesn't break anything.
