### PR TITLE
Remove resource bundle from podspec

### DIFF
--- a/Whisper.podspec
+++ b/Whisper.podspec
@@ -10,7 +10,6 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '8.0'
   s.requires_arc = true
   s.source_files = 'Source/**/*'
-  s.resource_bundles = { 'Whisper' => ['Images/*.{png}'] }
 
   s.frameworks = 'UIKit', 'Foundation'
 end


### PR DESCRIPTION
We don't use images at the moment, so it could be removed from resources.
