### PR TITLE
Feature text color for whispers

### DIFF
--- a/Demo/WhisperDemo/Podfile
+++ b/Demo/WhisperDemo/Podfile
@@ -5,4 +5,6 @@ platform :ios, '8.0'
 use_frameworks!
 inhibit_all_warnings!
 
-pod 'Whisper', path: '../../'
+target "WhisperDemo" do
+  pod 'Whisper', path: '../../'
+end

--- a/Demo/WhisperDemo/Podfile.lock
+++ b/Demo/WhisperDemo/Podfile.lock
@@ -6,9 +6,11 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   Whisper:
-    :path: ../../
+    :path: "../../"
 
 SPEC CHECKSUMS:
-  Whisper: 80f9eafa9d51dbc246f7c6aeb8aaa146a20cddce
+  Whisper: da0571029573d920edbf28ab9593635905faaa35
 
-COCOAPODS: 0.39.0.beta.4
+PODFILE CHECKSUM: 81845337b01379fa20ca9c4299ab339c135aa5a5
+
+COCOAPODS: 1.0.0.beta.2

--- a/Demo/WhisperDemo/WhisperDemo.xcodeproj/project.pbxproj
+++ b/Demo/WhisperDemo/WhisperDemo.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		29AD42A01BBC2BD2004292F1 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29AD429F1BBC2BD2004292F1 /* ViewController.swift */; };
 		29AD42A51BBC2BD2004292F1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 29AD42A41BBC2BD2004292F1 /* Assets.xcassets */; };
 		29AD42A81BBC2BD2004292F1 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 29AD42A61BBC2BD2004292F1 /* LaunchScreen.storyboard */; };
-		D01A974C417D6227CDD6240A /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6F0DEAB1F8C735F802579CE1 /* Pods.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		927D368A05BDABD5E87F619D /* Pods_WhisperDemo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3921969B70815F246AED7F27 /* Pods_WhisperDemo.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -37,9 +37,10 @@
 		29AD42A41BBC2BD2004292F1 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		29AD42A71BBC2BD2004292F1 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		29AD42A91BBC2BD2004292F1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		388682239575B0B26D39FB8E /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		3921969B70815F246AED7F27 /* Pods_WhisperDemo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WhisperDemo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F0DEAB1F8C735F802579CE1 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		9A9FBA4819B436EADFFB3462 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		955FFF144EC297785D2EF6F9 /* Pods-WhisperDemo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WhisperDemo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-WhisperDemo/Pods-WhisperDemo.debug.xcconfig"; sourceTree = "<group>"; };
+		E7E536866D2D92CA0E048ABC /* Pods-WhisperDemo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WhisperDemo.release.xcconfig"; path = "Pods/Target Support Files/Pods-WhisperDemo/Pods-WhisperDemo.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -54,7 +55,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D01A974C417D6227CDD6240A /* Pods.framework in Frameworks */,
+				927D368A05BDABD5E87F619D /* Pods_WhisperDemo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -65,6 +66,7 @@
 			isa = PBXGroup;
 			children = (
 				6F0DEAB1F8C735F802579CE1 /* Pods.framework */,
+				3921969B70815F246AED7F27 /* Pods_WhisperDemo.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -84,8 +86,8 @@
 				29AD429C1BBC2BD2004292F1 /* WhisperDemo */,
 				290531401C206A6400FB382C /* WhisperTests */,
 				29AD429B1BBC2BD2004292F1 /* Products */,
-				3FD1061CCFD319AE1B0565AB /* Pods */,
 				029D90BE27CCA78731543D55 /* Frameworks */,
+				C6105C06E05EE7306BB12C3D /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -111,11 +113,11 @@
 			path = WhisperDemo;
 			sourceTree = "<group>";
 		};
-		3FD1061CCFD319AE1B0565AB /* Pods */ = {
+		C6105C06E05EE7306BB12C3D /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				9A9FBA4819B436EADFFB3462 /* Pods.debug.xcconfig */,
-				388682239575B0B26D39FB8E /* Pods.release.xcconfig */,
+				955FFF144EC297785D2EF6F9 /* Pods-WhisperDemo.debug.xcconfig */,
+				E7E536866D2D92CA0E048ABC /* Pods-WhisperDemo.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -145,12 +147,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 29AD42AC1BBC2BD2004292F1 /* Build configuration list for PBXNativeTarget "WhisperDemo" */;
 			buildPhases = (
-				E2DA798603098B16D1DF794F /* Check Pods Manifest.lock */,
+				7C2AD771C3E0C8D8C952C8C1 /* Check Pods Manifest.lock */,
 				29AD42961BBC2BD2004292F1 /* Sources */,
 				29AD42971BBC2BD2004292F1 /* Frameworks */,
 				29AD42981BBC2BD2004292F1 /* Resources */,
-				4CB963C3B468A1C988A141BD /* Embed Pods Frameworks */,
-				3EA9AEA49A6C04C4367BD4A0 /* Copy Pods Resources */,
+				386529A60BE25BE05191D829 /* Embed Pods Frameworks */,
+				BCC353EC93296D0E781E45A8 /* Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -219,22 +221,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3EA9AEA49A6C04C4367BD4A0 /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		4CB963C3B468A1C988A141BD /* Embed Pods Frameworks */ = {
+		386529A60BE25BE05191D829 /* Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -246,10 +233,10 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods/Pods-frameworks.sh\"\n";
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-WhisperDemo/Pods-WhisperDemo-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		E2DA798603098B16D1DF794F /* Check Pods Manifest.lock */ = {
+		7C2AD771C3E0C8D8C952C8C1 /* Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -262,6 +249,21 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		BCC353EC93296D0E781E45A8 /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-WhisperDemo/Pods-WhisperDemo-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -418,7 +420,7 @@
 		};
 		29AD42AD1BBC2BD2004292F1 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9A9FBA4819B436EADFFB3462 /* Pods.debug.xcconfig */;
+			baseConfigurationReference = 955FFF144EC297785D2EF6F9 /* Pods-WhisperDemo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = WhisperDemo/Info.plist;
@@ -430,7 +432,7 @@
 		};
 		29AD42AE1BBC2BD2004292F1 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 388682239575B0B26D39FB8E /* Pods.release.xcconfig */;
+			baseConfigurationReference = E7E536866D2D92CA0E048ABC /* Pods-WhisperDemo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = WhisperDemo/Info.plist;

--- a/Demo/WhisperDemo/WhisperDemo/TableViewController.swift
+++ b/Demo/WhisperDemo/WhisperDemo/TableViewController.swift
@@ -28,7 +28,7 @@ class TableViewController: UITableViewController {
     super.viewDidAppear(animated)
 
     guard let navigationController = navigationController else { return }
-    let message = Message(title: "This message will silent in 3 seconds.", color: UIColor(red:0.89, green:0.09, blue:0.44, alpha:1))
+    let message = Message(title: "This message will silent in 3 seconds.", backgroundColor: UIColor(red:0.89, green:0.09, blue:0.44, alpha:1))
 
     Whisper(message, to: navigationController, action: .Present)
     Silent(navigationController, after: 3)

--- a/Demo/WhisperDemo/WhisperDemo/ViewController.swift
+++ b/Demo/WhisperDemo/WhisperDemo/ViewController.swift
@@ -116,7 +116,7 @@ class ViewController: UIViewController {
 
   func presentButtonDidPress(button: UIButton) {
     guard let navigationController = navigationController else { return }
-    let message = Message(title: "This message will silent in 3 seconds.", color: UIColor(red:0.89, green:0.09, blue:0.44, alpha:1))
+    let message = Message(title: "This message will silent in 3 seconds.", backgroundColor: UIColor(red:0.89, green:0.09, blue:0.44, alpha:1))
 
     Whisper(message, to: navigationController, action: .Present)
     Silent(navigationController, after: 3)
@@ -125,14 +125,15 @@ class ViewController: UIViewController {
   func showButtonDidPress(button: UIButton) {
     guard let navigationController = navigationController else { return }
 
-    let message = Message(title: "Showing all the things.", color: UIColor.blackColor())
+    let message = Message(title: "Showing all the things.", backgroundColor: UIColor.blackColor())
     Whisper(message, to: navigationController)
   }
 
   func presentPermanentButtonDidPress(button: UIButton) {
     guard let navigationController = navigationController else { return }
 
-    let message = Message(title: "This is a permanent Whisper.", color: UIColor(red:0.87, green:0.34, blue:0.05, alpha:1))
+    let message = Message(title: "This is a permanent Whisper.", textColor: UIColor(red:0.87, green:0.34, blue:0.05, alpha:1),
+      backgroundColor: UIColor(red:1.000, green:0.973, blue:0.733, alpha: 1))
     Whisper(message, to: navigationController, action: .Present)
   }
 

--- a/Source/Message.swift
+++ b/Source/Message.swift
@@ -3,12 +3,14 @@ import UIKit
 public struct Message {
 
   public var title: String
-  public var color: UIColor
+  public var textColor: UIColor
+  public var backgroundColor: UIColor
   public var images: [UIImage]?
 
-  public init(title: String, color: UIColor = UIColor.lightGrayColor(), images: [UIImage]? = nil) {
+  public init(title: String, textColor: UIColor = UIColor.whiteColor(), backgroundColor: UIColor = UIColor.lightGrayColor(), images: [UIImage]? = nil) {
     self.title = title
-    self.color = color
+    self.textColor = textColor
+    self.backgroundColor = backgroundColor
     self.images = images
   }
 }

--- a/Source/WhisperFactory.swift
+++ b/Source/WhisperFactory.swift
@@ -88,7 +88,7 @@ class WhisperFactory: NSObject {
 
   func silentWhisper(controller: UINavigationController, after: NSTimeInterval) {
     navigationController = controller
-    
+
     var whisperSubview: WhisperView? = nil
     for subview in navigationController.navigationBar.subviews {
       if let whisper = subview as? WhisperView {
@@ -152,10 +152,11 @@ class WhisperFactory: NSObject {
     hideView()
 
     let title = message.title
-    let color = message.color
+    let textColor = message.textColor
+    let backgroundColor = message.backgroundColor
     let action = action.rawValue
 
-    var array = ["title": title, "color": color, "action": action]
+    var array = ["title": title, "textColor" : textColor, "backgroundColor": backgroundColor, "action": action]
     if let images = message.images { array["images"] = images }
 
     presentTimer = NSTimer.scheduledTimerWithTimeInterval(AnimationTiming.movement * 1.1, target: self,
@@ -185,7 +186,8 @@ class WhisperFactory: NSObject {
   func presentFired(timer: NSTimer) {
     guard let userInfo = timer.userInfo,
       title = userInfo["title"] as? String,
-      color = userInfo["color"] as? UIColor,
+      textColor = userInfo["textColor"] as? UIColor,
+      backgroundColor = userInfo["backgroundColor"] as? UIColor,
       actionString = userInfo["action"] as? String else { return }
 
     var images: [UIImage]? = nil
@@ -193,7 +195,7 @@ class WhisperFactory: NSObject {
     if let imageArray = userInfo["images"] as? [UIImage]? { images = imageArray }
 
     let action = Action(rawValue: actionString)
-    let message = Message(title: title, color: color, images: images)
+    let message = Message(title: title, textColor: textColor, backgroundColor: backgroundColor, images: images)
 
     whisperView = WhisperView(height: navigationController.navigationBar.frame.height, message: message)
     navigationController.navigationBar.addSubview(whisperView)

--- a/Source/WhisperView.swift
+++ b/Source/WhisperView.swift
@@ -45,6 +45,7 @@ public class WhisperView: UIView {
 
     titleLabel.text = message.title
     backgroundColor = message.color
+    titleLabel.textColor = message.textColor
 
     if let images = whisperImages where images.count > 1 {
       complementImageView.animationImages = images

--- a/Source/WhisperView.swift
+++ b/Source/WhisperView.swift
@@ -18,7 +18,6 @@ public class WhisperView: UIView {
   public lazy var titleLabel: UILabel = {
     let label = UILabel()
     label.textAlignment = .Center
-    label.textColor = UIColor.whiteColor()
     label.font = UIFont(name: "HelveticaNeue", size: 13)
     label.frame.size.width = UIScreen.mainScreen().bounds.width - 60
 
@@ -44,8 +43,8 @@ public class WhisperView: UIView {
     super.init(frame: CGRectZero)
 
     titleLabel.text = message.title
-    backgroundColor = message.color
     titleLabel.textColor = message.textColor
+    backgroundColor = message.backgroundColor
 
     if let images = whisperImages where images.count > 1 {
       complementImageView.animationImages = images


### PR DESCRIPTION
This PR introduces some breaking changes, the public API for the creation of a message has different label names now. This would mean that the next version would be `2.0.0`.

Ref http://semver.org

`color` is now `backgroundColor` and there is a new label called `titleColor`.

The default `textColor` for a Message is still white so you don’t need to set it if you don’t want to.

<img width="487" alt="screen shot 2016-01-15 at 11 41 52" src="https://cloud.githubusercontent.com/assets/57446/12351408/92753e62-bb7d-11e5-8c58-b12fc28d50ce.PNG">

Fixes https://github.com/hyperoslo/Whisper/issues/36
