### PR TITLE
Update podspec with new version

### DIFF
--- a/Whisper.podspec
+++ b/Whisper.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Whisper"
   s.summary          = "Whisper is a component that will make the task of display messages and in-app notifications simple."
-  s.version          = "1.1.0"
+  s.version          = "2.0.0"
   s.homepage         = "https://github.com/hyperoslo/Whisper"
   s.license          = 'MIT'
   s.author           = { "Hyper Interaktiv AS" => "ios@hyper.no" }


### PR DESCRIPTION
We need to bump the version to a new major one because the public API has changed for Whispers.
