### PR TITLE
Add Config with modifyInset flag

### DIFF
--- a/Source/Config.swift
+++ b/Source/Config.swift
@@ -1,3 +1,3 @@
 public struct Config {
-  public static var move: Bool = true
+  public static var modifyInset: Bool = true
 }

--- a/Source/Config.swift
+++ b/Source/Config.swift
@@ -1,0 +1,3 @@
+public struct Config {
+  public static var move: Bool = true
+}

--- a/Source/WhisperFactory.swift
+++ b/Source/WhisperFactory.swift
@@ -216,7 +216,7 @@ class WhisperFactory: NSObject {
   // MARK: - Animations
 
   func moveControllerViews(down: Bool) {
-    guard Config.move else { return }
+    guard Config.modifyInset else { return }
     guard let visibleController = navigationController.visibleViewController else { return }
 
     let stackCount = navigationController.viewControllers.count

--- a/Source/WhisperFactory.swift
+++ b/Source/WhisperFactory.swift
@@ -216,6 +216,7 @@ class WhisperFactory: NSObject {
   // MARK: - Animations
 
   func moveControllerViews(down: Bool) {
+    guard Config.move else { return }
     guard let visibleController = navigationController.visibleViewController else { return }
 
     let stackCount = navigationController.viewControllers.count

--- a/Whisper.xcodeproj/project.pbxproj
+++ b/Whisper.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		290531131C20517E00FB382C /* WhisperFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2905310B1C20517E00FB382C /* WhisperFactory.swift */; };
 		290531141C20517E00FB382C /* WhisperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2905310C1C20517E00FB382C /* WhisperView.swift */; };
 		290531151C20517E00FB382C /* WhistleFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2905310D1C20517E00FB382C /* WhistleFactory.swift */; };
+		D5170D641C4955F3006F2F37 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5170D631C4955F3006F2F37 /* Config.swift */; settings = {ASSET_TAGS = (); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -26,6 +27,7 @@
 		2905310C1C20517E00FB382C /* WhisperView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WhisperView.swift; sourceTree = "<group>"; };
 		2905310D1C20517E00FB382C /* WhistleFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WhistleFactory.swift; sourceTree = "<group>"; };
 		290531171C2051F400FB382C /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D5170D631C4955F3006F2F37 /* Config.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -65,6 +67,7 @@
 				2905310B1C20517E00FB382C /* WhisperFactory.swift */,
 				2905310C1C20517E00FB382C /* WhisperView.swift */,
 				2905310D1C20517E00FB382C /* WhistleFactory.swift */,
+				D5170D631C4955F3006F2F37 /* Config.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -169,6 +172,7 @@
 				290531151C20517E00FB382C /* WhistleFactory.swift in Sources */,
 				290531111C20517E00FB382C /* Message.swift in Sources */,
 				290531131C20517E00FB382C /* WhisperFactory.swift in Sources */,
+				D5170D641C4955F3006F2F37 /* Config.swift in Sources */,
 				290531101C20517E00FB382C /* FontList.swift in Sources */,
 				2905310F1C20517E00FB382C /* ColorList.swift in Sources */,
 			);


### PR DESCRIPTION
@zenangst @RamonGilabert So apparently we really need to disable `moveControllerViews` function, so it doesn't modify inset. It's `true` by default, so it's not some breaking change.
