### PR TITLE
retaining content insets, not setting as zero

### DIFF
--- a/Source/WhisperFactory.swift
+++ b/Source/WhisperFactory.swift
@@ -242,14 +242,14 @@ class WhisperFactory: NSObject {
 
     if let tableView = viewController.view as? UITableView
       where viewController is UITableViewController {
-        tableView.contentInset = UIEdgeInsetsMake(tableView.contentInset.top + edgeInsetHeight, 0, 0, 0)
+        tableView.contentInset = UIEdgeInsetsMake(tableView.contentInset.top + edgeInsetHeight, tableView.contentInset.left, tableView.contentInset.bottom, tableView.contentInset.right)
     } else if let collectionView = viewController.view as? UICollectionView
       where viewController is UICollectionViewController {
-        collectionView.contentInset = UIEdgeInsetsMake(collectionView.contentInset.top + edgeInsetHeight, 0, 0, 0)
+        collectionView.contentInset = UIEdgeInsetsMake(collectionView.contentInset.top + edgeInsetHeight, collectionView.contentInset.left, collectionView.contentInset.bottom, collectionView.contentInset.right)
     } else {
       for view in viewController.view.subviews {
         if let scrollView = view as? UIScrollView {
-          scrollView.contentInset = UIEdgeInsetsMake(scrollView.contentInset.top + edgeInsetHeight, 0, 0, 0)
+          scrollView.contentInset = UIEdgeInsetsMake(scrollView.contentInset.top + edgeInsetHeight, scrollView.contentInset.left, scrollView.contentInset.bottom, scrollView.contentInset.right)
         }
       }
     }


### PR DESCRIPTION
In WhisperFactory, while moving the view controller scroll views, except for top, all insets are being set to 0. They should be unchanged, not 0.
