### PR TITLE
Fix wrong Whisper size on orientation/size class change

### DIFF
--- a/Source/WhisperFactory.swift
+++ b/Source/WhisperFactory.swift
@@ -58,7 +58,7 @@ class WhisperFactory: NSObject {
     }
 
     if !containsWhisper {
-      whisperView = WhisperView(height: navigationController.navigationBar.frame.height, message: message)
+      whisperView = WhisperView(size: navigationController.navigationBar.frame.size, message: message)
       whisperView.frame.size.height = 0
       var maximumY = navigationController.navigationBar.frame.height
 
@@ -198,7 +198,7 @@ class WhisperFactory: NSObject {
     let action = WhisperAction(rawValue: actionString)
     let message = Message(title: title, textColor: textColor, backgroundColor: backgroundColor, images: images)
 
-    whisperView = WhisperView(height: navigationController.navigationBar.frame.height, message: message)
+    whisperView = WhisperView(size: navigationController.navigationBar.frame.size, message: message)
     navigationController.navigationBar.addSubview(whisperView)
     whisperView.frame.size.height = 0
 
@@ -269,7 +269,7 @@ class WhisperFactory: NSObject {
       whisper.frame = CGRect(
         x: whisper.frame.origin.x,
         y: maximumY,
-        width: UIScreen.mainScreen().bounds.width,
+        width: navigationController.navigationBar.frame.width,
         height: whisper.frame.size.height)
       whisper.setupFrames()
     }

--- a/Source/WhisperView.swift
+++ b/Source/WhisperView.swift
@@ -37,8 +37,8 @@ public class WhisperView: UIView {
 
   // MARK: - Initializers
 
-  init(height: CGFloat, message: Message) {
-    self.height = height
+  init(size: CGSize, message: Message) {
+    self.height = size.height
     self.whisperImages = message.images
     super.init(frame: CGRectZero)
 
@@ -54,7 +54,7 @@ public class WhisperView: UIView {
       complementImageView.image = whisperImages?.first
     }
 
-    frame = CGRectMake(0, height, UIScreen.mainScreen().bounds.width, Dimensions.height)
+    frame = CGRectMake(0, height, size.width, Dimensions.height)
     for subview in transformViews { addSubview(subview) }
 
     titleLabel.sizeToFit()
@@ -65,6 +65,12 @@ public class WhisperView: UIView {
   public required init?(coder aDecoder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
+
+  public override func layoutSubviews() {
+    super.layoutSubviews()
+    setupFrames()
+  }
+    
 }
 
 // MARK: - Layout
@@ -72,6 +78,7 @@ public class WhisperView: UIView {
 extension WhisperView {
 
   func setupFrames() {
+
     if whisperImages != nil {
       titleLabel.frame = CGRect(
         x: (frame.width - titleLabel.frame.width) / 2 + 20,
@@ -91,5 +98,7 @@ extension WhisperView {
         width: titleLabel.frame.width,
         height: frame.height)
     }
+    guard let superviewWidth = superview?.frame.width else { return }
+    frame.size = CGSize(width: superviewWidth, height: frame.height)
   }
 }


### PR DESCRIPTION
This PR partly addresses #90 and fixes issues with Whisper on rotation and size-class change.

Whistles & notifications aren't fixed, and i'm thinking about best solution, that also can be related to 1 issue left with messages: when app is resized without size class change (for example, from 2/3 mode to fullscreen) there is no way to detect this (layoutSubviews and traitCollectionDidChange aren't called). 
It seems like only way  to fix that is to use `func viewWillTransitionToSize(_ size: CGSize, withTransitionCoordinator coordinator: UIViewControllerTransitionCoordinator)`

Probably, good solution will be to detect size change by ading childViewController with approach similar to [this one](http://irace.me/lifecycle-behaviors) or using autolayout instead manual frame calculations can also be considered as an option.

Would be cool to get some feedback on this, thanks!
