### PR TITLE
Rename global functions

### DIFF
--- a/Demo/WhisperDemo/WhisperDemo/TableViewController.swift
+++ b/Demo/WhisperDemo/WhisperDemo/TableViewController.swift
@@ -31,7 +31,7 @@ class TableViewController: UITableViewController {
     let message = Message(title: "This message will silent in 3 seconds.", backgroundColor: UIColor(red:0.89, green:0.09, blue:0.44, alpha:1))
 
     show(whisper: message, to: navigationController, action: .Present)
-    hide(whisper: navigationController, after: 3)
+    hide(whisperFrom: navigationController, after: 3)
   }
 
   // MARK: - TableView methods

--- a/Demo/WhisperDemo/WhisperDemo/TableViewController.swift
+++ b/Demo/WhisperDemo/WhisperDemo/TableViewController.swift
@@ -30,8 +30,8 @@ class TableViewController: UITableViewController {
     guard let navigationController = navigationController else { return }
     let message = Message(title: "This message will silent in 3 seconds.", backgroundColor: UIColor(red:0.89, green:0.09, blue:0.44, alpha:1))
 
-    whisper(message, to: navigationController, action: .Present)
-    silent(navigationController, after: 3)
+    show(whisper: message, to: navigationController, action: .Present)
+    hide(whisper: navigationController, after: 3)
   }
 
   // MARK: - TableView methods

--- a/Demo/WhisperDemo/WhisperDemo/ViewController.swift
+++ b/Demo/WhisperDemo/WhisperDemo/ViewController.swift
@@ -128,15 +128,15 @@ class ViewController: UIViewController {
     guard let navigationController = navigationController else { return }
     let message = Message(title: "This message will silent in 3 seconds.", backgroundColor: UIColor(red:0.89, green:0.09, blue:0.44, alpha:1))
 
-    whisper(message, to: navigationController, action: .Present)
-    silent(navigationController, after: 3)
+    show(whisper: message, to: navigationController, action: .Present)
+    hide(whisper: navigationController, after: 3)
   }
 
   func showButtonDidPress(button: UIButton) {
     guard let navigationController = navigationController else { return }
 
     let message = Message(title: "Showing all the things.", backgroundColor: UIColor.blackColor())
-    whisper(message, to: navigationController)
+    show(whisper: message, to: navigationController)
   }
 
   func presentPermanentButtonDidPress(button: UIButton) {
@@ -144,14 +144,14 @@ class ViewController: UIViewController {
 
     let message = Message(title: "This is a permanent Whisper.", textColor: UIColor(red:0.87, green:0.34, blue:0.05, alpha:1),
       backgroundColor: UIColor(red:1.000, green:0.973, blue:0.733, alpha: 1))
-    whisper(message, to: navigationController, action: .Present)
+    show(whisper: message, to: navigationController, action: .Present)
   }
 
   func presentNotificationDidPress(button: UIButton) {
     let announcement = Announcement(title: "Ramon Gilabert", subtitle: "Vadym Markov just commented your post", image: UIImage(named: "avatar"))
 
     if let navigationController = navigationController {
-      shout(announcement, to: navigationController, completion: {
+      show(shout: announcement, to: navigationController, completion: {
         print("The shout was silent.")
       })
     }
@@ -166,7 +166,7 @@ class ViewController: UIViewController {
     let murmur = Murmur(title: "This is a small whistle...",
       backgroundColor: UIColor(red: 0.975, green: 0.975, blue: 0.975, alpha: 1))
 
-    whistle(murmur)
+    show(whistle: murmur)
   }
 
   func presentWhistleButtonDidPress(button: UIButton) {
@@ -174,7 +174,7 @@ class ViewController: UIViewController {
                         backgroundColor: UIColor.redColor(),
                         titleColor: UIColor.whiteColor())
 
-    whistle(murmur, action: .Present)
+    show(whistle: murmur, action: .Present)
   }
 
   // MARK - Configuration

--- a/Demo/WhisperDemo/WhisperDemo/ViewController.swift
+++ b/Demo/WhisperDemo/WhisperDemo/ViewController.swift
@@ -129,7 +129,7 @@ class ViewController: UIViewController {
     let message = Message(title: "This message will silent in 3 seconds.", backgroundColor: UIColor(red:0.89, green:0.09, blue:0.44, alpha:1))
 
     show(whisper: message, to: navigationController, action: .Present)
-    hide(whisper: navigationController, after: 3)
+    hide(whisperFrom: navigationController, after: 3)
   }
 
   func showButtonDidPress(button: UIButton) {

--- a/Source/ShoutFactory.swift
+++ b/Source/ShoutFactory.swift
@@ -2,10 +2,6 @@ import UIKit
 
 let shoutView = ShoutView()
 
-public func shout(announcement: Announcement, to: UIViewController, completion: (() -> ())? = {}) {
-  shoutView.craft(announcement, to: to, completion: completion)
-}
-
 public class ShoutView: UIView {
 
   public struct Dimensions {

--- a/Source/Showing.swift
+++ b/Source/Showing.swift
@@ -4,7 +4,7 @@ public func show(whisper message: Message, to: UINavigationController, action: W
   whisperFactory.craft(message, navigationController: to, action: action)
 }
 
-public func hide(whisper from: UINavigationController, after: NSTimeInterval = 0) {
+public func hide(whisperFrom from: UINavigationController, after: NSTimeInterval = 0) {
   whisperFactory.silentWhisper(from, after: after)
 }
 
@@ -16,6 +16,6 @@ public func show(whistle murmur: Murmur, action: WhistleAction = .Present) {
   whistleFactory.whistler(murmur, action: action)
 }
 
-public func hide(whistle after: NSTimeInterval = 0) {
+public func hide(whistleAfter after: NSTimeInterval = 0) {
   whistleFactory.calm(after: after)
 }

--- a/Source/Showing.swift
+++ b/Source/Showing.swift
@@ -1,0 +1,21 @@
+import UIKit
+
+public func show(whisper message: Message, to: UINavigationController, action: WhisperAction = .Present) {
+  whisperFactory.craft(message, navigationController: to, action: action)
+}
+
+public func hide(whisper from: UINavigationController, after: NSTimeInterval = 0) {
+  whisperFactory.silentWhisper(from, after: after)
+}
+
+public func show(shout announcement: Announcement, to: UIViewController, completion: (() -> Void)? = nil) {
+  shoutView.craft(announcement, to: to, completion: completion)
+}
+
+public func show(whistle murmur: Murmur, action: WhistleAction = .Present) {
+  whistleFactory.whistler(murmur, action: action)
+}
+
+public func hide(whistle after: NSTimeInterval = 0) {
+  whistleFactory.calm(after: after)
+}

--- a/Source/WhisperFactory.swift
+++ b/Source/WhisperFactory.swift
@@ -7,14 +7,6 @@ public enum WhisperAction: String {
 
 let whisperFactory: WhisperFactory = WhisperFactory()
 
-public func whisper(message: Message, to: UINavigationController, action: WhisperAction = .Show) {
-  whisperFactory.craft(message, navigationController: to, action: action)
-}
-
-public func silent(controller: UINavigationController, after: NSTimeInterval = 0) {
-  whisperFactory.silentWhisper(controller, after: after)
-}
-
 class WhisperFactory: NSObject {
 
   struct AnimationTiming {

--- a/Source/WhistleFactory.swift
+++ b/Source/WhistleFactory.swift
@@ -7,14 +7,6 @@ public enum WhistleAction {
 
 let whistleFactory = WhistleFactory()
 
-public func whistle(murmur: Murmur, action: WhistleAction = .Show(1.5)) {
-  whistleFactory.whistler(murmur, action: action)
-}
-
-public func calm(after after: NSTimeInterval = 0) {
-  whistleFactory.calm(after: after)
-}
-
 public class WhistleFactory: UIViewController {
 
   public lazy var whistleWindow: UIWindow = UIWindow()


### PR DESCRIPTION
As a follow up to https://github.com/hyperoslo/Whisper/pull/89
- Add `show/hide` functions, which make it easy to remember. If we ever have more kinds of message, we can do the same way
- Make use of first parameter name in function to specify the type of UI, so we have something like

``` swift
show(whisper: message, to: navigationController, action: .Present)
hide(whisper: navigationController, after: 3)
show(whistle: murmur, action: .Present)
```
