### PR TITLE
Restore the previously *last* top window on hide()

### DIFF
--- a/Source/WhistleFactory.swift
+++ b/Source/WhistleFactory.swift
@@ -143,7 +143,7 @@ open class WhistleFactory: UIViewController {
     UIView.animate(withDuration: 0.2, animations: {
       self.whistleWindow.frame.origin.y = finalOrigin
       }, completion: { _ in
-        if let window = UIApplication.shared.windows.filter({ $0 != self.whistleWindow }).first {
+        if let window = UIApplication.shared.windows.filter({ $0 != self.whistleWindow }).last {
           window.makeKeyAndVisible()
           self.whistleWindow.windowLevel = UIWindowLevelNormal - 1
           window.rootViewController?.setNeedsStatusBarAppearanceUpdate()


### PR DESCRIPTION
Fixes https://github.com/hyperoslo/Whisper/issues/88
As per https://developer.apple.com/reference/uikit/uiapplication/1623104-windows

> the last window in the array is on top of all other app windows.


` UIApplication.shared.windows.filter({ $0 != self.whistleWindow }).first ` will return the _less_ visible window which is not the previous more visible if there are more than 2 windows as happened on https://github.com/hyperoslo/Whisper/issues/88

It currently works when the filter returns just 1 window as `[w].last == [w].first` ;)