### PR TITLE
Become visible without claiming focus

### DIFF
--- a/Source/WhistleFactory.swift
+++ b/Source/WhistleFactory.swift
@@ -132,7 +132,7 @@ open class WhistleFactory: UIViewController {
 
     let initialOrigin = whistleWindow.frame.origin.y
     whistleWindow.frame.origin.y = initialOrigin - titleLabelHeight
-    whistleWindow.makeKeyAndVisible()
+    whistleWindow.isHidden = false
     UIView.animate(withDuration: 0.2, animations: {
       self.whistleWindow.frame.origin.y = initialOrigin
     })


### PR DESCRIPTION
Claiming focus will dismiss keyboards, which is annoying when you are typing when a message shows up.

Sure, I can imagine that you want to claim the focus, but I think in most cases, it's better to leave the focus on the main window.