### PR TITLE
Exposing height Constraint

### DIFF
--- a/Source/WhisperView.swift
+++ b/Source/WhisperView.swift
@@ -6,8 +6,8 @@ public protocol NotificationControllerDelegate: class {
 
 open class WhisperView: UIView {
 
-  struct Dimensions {
-    static let height: CGFloat = 24
+  public struct Dimensions {
+    public static let height: CGFloat = 24
     static let offsetHeight: CGFloat = height * 2
     static let imageSize: CGFloat = 14
     static let loaderTitleOffset: CGFloat = 5


### PR DESCRIPTION
Exposing the height constraint allows developers to have more customization by allowing the view to slide down with the the whisper preventing it from covering over the view when being presented. Height + TopLayoutGuide.length lets devs know how far to move the underlying view. 