### PR TITLE
Use correct window for makeKeyAndVisible

### DIFF
--- a/Source/WhistleFactory.swift
+++ b/Source/WhistleFactory.swift
@@ -31,6 +31,8 @@ open class WhistleFactory: UIViewController {
   open var viewController: UIViewController?
   open var hideTimer = Timer()
 
+  private weak var previousKeyWindow: UIWindow?
+
   // MARK: - Initializers
 
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
@@ -130,6 +132,10 @@ open class WhistleFactory: UIViewController {
   public func present() {
     hideTimer.invalidate()
 
+    if UIApplication.shared.keyWindow != whistleWindow {
+      previousKeyWindow = UIApplication.shared.keyWindow
+    }
+
     let initialOrigin = whistleWindow.frame.origin.y
     whistleWindow.frame.origin.y = initialOrigin - titleLabelHeight
     whistleWindow.makeKeyAndVisible()
@@ -143,9 +149,10 @@ open class WhistleFactory: UIViewController {
     UIView.animate(withDuration: 0.2, animations: {
       self.whistleWindow.frame.origin.y = finalOrigin
       }, completion: { _ in
-        if let window = UIApplication.shared.windows.filter({ $0 != self.whistleWindow }).first {
+        if let window = self.previousKeyWindow {
           window.makeKeyAndVisible()
           self.whistleWindow.windowLevel = UIWindowLevelNormal - 1
+          self.previousKeyWindow = nil
           window.rootViewController?.setNeedsStatusBarAppearanceUpdate()
         }
     })


### PR DESCRIPTION
When apps have multiple windows it's important to invoke
makeKeyAndVisble on the correct window after hiding a whistle.

Fix #156