### PR TITLE
More shout customizations. Fixes shout issues.

### DIFF
--- a/Demo/WhisperDemo/Podfile.lock
+++ b/Demo/WhisperDemo/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Whisper (4.0.0)
+  - Whisper (5.0.0)
 
 DEPENDENCIES:
   - Whisper (from `../../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../../"
 
 SPEC CHECKSUMS:
-  Whisper: 08be92623311f8e53201e62e17f6d7b9599a4714
+  Whisper: 39b833d0f279912a7f38a19c4ba603435514a550
 
 PODFILE CHECKSUM: e20a3f258a5cd7e57b37f62aadb18fd14d135133
 

--- a/Source/Message.swift
+++ b/Source/Message.swift
@@ -22,13 +22,17 @@ public struct Announcement {
   public var image: UIImage?
   public var duration: TimeInterval
   public var action: (() -> Void)?
+  // Closure which is called when notification is dismissed manually
+  // not by automatic timer
+  public var dismissed: (() -> Void)?
 
-  public init(title: String, subtitle: String? = nil, image: UIImage? = nil, duration: TimeInterval = 2, action: (() -> Void)? = nil) {
+  public init(title: String, subtitle: String? = nil, image: UIImage? = nil, duration: TimeInterval = 2, action: (() -> Void)? = nil, dismissed: (() -> Void)? = nil) {
     self.title = title
     self.subtitle = subtitle
     self.image = image
     self.duration = duration
     self.action = action
+    self.dismissed = dismissed
   }
 }
 

--- a/Source/ShoutFactory.swift
+++ b/Source/ShoutFactory.swift
@@ -5,8 +5,8 @@ let shoutView = ShoutView()
 open class ShoutView: UIView {
 
   public struct Dimensions {
-    public static var contentInsets: UIEdgeInsets = UIEdgeInsets(top: 5, left: 15, bottom: 5, right: 15)
-    public static var textToImageMargin: CGFloat = 15
+    public static var contentInsets: UIEdgeInsets = UIEdgeInsets(top: 1, left: 18, bottom: 1, right: 18)
+    public static var textToImageMargin: CGFloat = 9
     public static let indicatorHeight: CGFloat = 6
     public static let indicatorWidth: CGFloat = 50
     public static let indicatorBottomMargin: CGFloat = 5

--- a/Source/ShoutFactory.swift
+++ b/Source/ShoutFactory.swift
@@ -168,8 +168,8 @@ open class ShoutView: UIView {
     let spaceBetweenLabels: CGFloat = 2
     let indicatorTakenHeight = Dimensions.indicatorBottomMargin + Dimensions.indicatorHeight
     
-    let zz = convert(CGRect(x: 0, y: 0, width: superview.frame.width, height: 1), to: UIApplication.shared.keyWindow)
-    let intersectsStatusBar = zz.intersects(UIApplication.shared.statusBarFrame)
+    let checkFrame = convert(CGRect(x: 0, y: 0, width: superview.frame.width, height: 1), to: UIApplication.shared.keyWindow)
+    let intersectsStatusBar = checkFrame.intersects(UIApplication.shared.statusBarFrame)
     let absoluteContentInsets: UIEdgeInsets = UIEdgeInsets(top: Dimensions.contentInsets.top + (UIApplication.shared.isStatusBarHidden || !intersectsStatusBar ? indicatorTakenHeight : 20), left: Dimensions.contentInsets.left, bottom: Dimensions.contentInsets.bottom, right: Dimensions.contentInsets.right)
     
     let textOffsetX = absoluteContentInsets.left + (imageView.image != nil ? imageView.frame.width + Dimensions.textToImageMargin : 0)

--- a/Source/ShoutFactory.swift
+++ b/Source/ShoutFactory.swift
@@ -19,7 +19,8 @@ open class ShoutView: UIView {
     view.backgroundColor = ColorList.Shout.background
     view.alpha = 0.98
     view.clipsToBounds = true
-
+    view.autoresizingMask = [.flexibleWidth]
+    
     return view
     }()
 
@@ -80,12 +81,14 @@ open class ShoutView: UIView {
 
   private var subtitleLabelOriginalHeight: CGFloat = 0
   private var internalHeight: CGFloat = 0
-
+  private var didRotate: Bool = false
+    
   // MARK: - Initializers
 
   public override init(frame: CGRect) {
     super.init(frame: frame)
 
+    autoresizingMask = [.flexibleWidth]
     addSubview(backgroundView)
     [imageView, titleLabel, subtitleLabel, indicatorView].forEach {
       $0.autoresizingMask = []
@@ -112,6 +115,13 @@ open class ShoutView: UIView {
   deinit {
     NotificationCenter.default.removeObserver(self, name: NSNotification.Name.UIDeviceOrientationDidChange, object: nil)
   }
+    
+  open override func layoutSubviews() {
+    super.layoutSubviews()
+    if didRotate {
+      setupFrames(resetHeight: false)
+    }
+  }
 
   // MARK: - Configuration
 
@@ -135,8 +145,6 @@ open class ShoutView: UIView {
     displayTimer.invalidate()
     displayTimer = Timer.scheduledTimer(timeInterval: announcement.duration,
       target: self, selector: #selector(ShoutView.displayTimerDidFire), userInfo: nil, repeats: false)
-
-    setupFrames()
   }
 
   open func shout(to controller: UIViewController) {
@@ -151,7 +159,9 @@ open class ShoutView: UIView {
 
   // MARK: - Setup
 
-  public func setupFrames() {
+  public func setupFrames(resetHeight: Bool = true) {
+    didRotate = false
+    
     guard let superview = superview else { return }
     
     let totalWidth = superview.frame.width
@@ -189,8 +199,9 @@ open class ShoutView: UIView {
       $0.frame.origin.y = labelY
       labelY += $0.frame.size.height + spaceBetweenLabels
     }
-    
-    frame = CGRect(x: 0, y: 0, width: totalWidth, height: containerHeight + Dimensions.touchOffset)
+    if resetHeight {
+      frame = CGRect(x: 0, y: 0, width: totalWidth, height: containerHeight + Dimensions.touchOffset)
+    }
     internalHeight = containerHeight
   }
 
@@ -287,6 +298,6 @@ open class ShoutView: UIView {
   // MARK: - Handling screen orientation
 
   func orientationDidChange() {
-    setupFrames()
+    didRotate = true
   }
 }

--- a/Source/ShoutFactory.swift
+++ b/Source/ShoutFactory.swift
@@ -142,6 +142,7 @@ open class ShoutView: UIView {
   open func shout(to controller: UIViewController) {
     controller.view.addSubview(self)
 
+    setupFrames()
     frame.size.height = 0
     UIView.animate(withDuration: 0.35, animations: {
       self.frame.size.height = self.internalHeight + Dimensions.touchOffset
@@ -151,11 +152,15 @@ open class ShoutView: UIView {
   // MARK: - Setup
 
   public func setupFrames() {
-    // totalWidth should be dependent on navigation controller's width
-    // in which the shout will be shown
-    let totalWidth = UIScreen.main.bounds.width
+    guard let superview = superview else { return }
+    
+    let totalWidth = superview.frame.width
     let spaceBetweenLabels: CGFloat = 2
-    let absoluteContentInsets: UIEdgeInsets = UIEdgeInsets(top: Dimensions.contentInsets.top + (UIApplication.shared.isStatusBarHidden ? 0 : 20), left: Dimensions.contentInsets.left, bottom: Dimensions.contentInsets.bottom, right: Dimensions.contentInsets.right)
+    let indicatorTakenHeight = Dimensions.indicatorBottomMargin + Dimensions.indicatorHeight
+    
+    let zz = convert(CGRect(x: 0, y: 0, width: superview.frame.width, height: 1), to: UIApplication.shared.keyWindow)
+    let intersectsStatusBar = zz.intersects(UIApplication.shared.statusBarFrame)
+    let absoluteContentInsets: UIEdgeInsets = UIEdgeInsets(top: Dimensions.contentInsets.top + (UIApplication.shared.isStatusBarHidden || !intersectsStatusBar ? indicatorTakenHeight : 20), left: Dimensions.contentInsets.left, bottom: Dimensions.contentInsets.bottom, right: Dimensions.contentInsets.right)
     
     let textOffsetX = absoluteContentInsets.left + (imageView.image != nil ? imageView.frame.width + Dimensions.textToImageMargin : 0)
     let labelWidth = totalWidth - textOffsetX - absoluteContentInsets.right
@@ -174,7 +179,6 @@ open class ShoutView: UIView {
     }
     
     let contentHeight = max(labelsHeight, imageView.frame.height)
-    let indicatorTakenHeight = Dimensions.indicatorBottomMargin + Dimensions.indicatorHeight
     let containerHeight = absoluteContentInsets.top + contentHeight + absoluteContentInsets.bottom + indicatorTakenHeight
     
     imageView.frame.origin.x = absoluteContentInsets.left

--- a/Source/ShoutFactory.swift
+++ b/Source/ShoutFactory.swift
@@ -258,17 +258,26 @@ open class ShoutView: UIView {
       }
     } else {
       panGestureActive = false
-      let height = translation.y < -5 || shouldSilent ? 0 : internalHeight
-
+      // it was either dragged significantly up/down or timer flagged it to be closesd
+      let shouldOpen = translation.y > 5
+      let forceDismissed = translation.y < -5
+      let shouldDismiss = shouldOpen || forceDismissed || shouldSilent
+      let height = shouldDismiss ? 0 : internalHeight
+      
       subtitleLabel.numberOfLines = 2
       subtitleLabel.sizeToFit()
       
       UIView.animate(withDuration: 0.2, animations: {
         self.frame.size.height = height + Dimensions.touchOffset
       }, completion: { _ in
-          if translation.y < -5 {
-            self.completion?()
-            self.removeFromSuperview()
+        if shouldOpen {
+          self.announcement?.action?()
+        } else if forceDismissed {
+          self.announcement?.dismissed?()
+        }
+        if shouldDismiss {
+          self.completion?()
+          self.removeFromSuperview()
         }
       })
     }

--- a/Source/ShoutFactory.swift
+++ b/Source/ShoutFactory.swift
@@ -5,6 +5,7 @@ let shoutView = ShoutView()
 open class ShoutView: UIView {
 
   public struct Dimensions {
+    public static var imageRoundedCorners: Bool = true
     public static var contentInsets: UIEdgeInsets = UIEdgeInsets(top: 1, left: 18, bottom: 1, right: 18)
     public static var textToImageMargin: CGFloat = 9
     public static let indicatorHeight: CGFloat = 6
@@ -33,7 +34,6 @@ open class ShoutView: UIView {
 
   open fileprivate(set) lazy var imageView: UIImageView = {
     let imageView = UIImageView()
-    imageView.layer.cornerRadius = Dimensions.imageSize / 2
     imageView.clipsToBounds = true
     imageView.contentMode = .scaleAspectFill
 
@@ -128,6 +128,7 @@ open class ShoutView: UIView {
     self.announcement = announcement
     imageView.image = announcement.image
     imageView.sizeToFit()
+    imageView.layer.cornerRadius = Dimensions.imageRoundedCorners ? (min(imageView.frame.width, imageView.frame.height) / 2) : 0
     titleLabel.text = announcement.title
     subtitleLabel.text = announcement.subtitle
 


### PR DESCRIPTION
In my use case I needed more customization of shout notification, so I've somehwat revamped some layout calculation making it possible to have any size image and centered content giving possibility to set content insets setting `contentInsets` property. More or less everything is displayed like:

<img width="831" alt="screen shot 2017-06-02 at 11 29 45" src="https://user-images.githubusercontent.com/3721061/26864912-1ae9a30c-4b63-11e7-8fd2-72ce7f571a50.png">

One more thing is that I needed to show shout notification in popup view, so instead of getting `UIScreen.main` frame I'm adapting to superview's frame. I guess that's an arguable thing if that's a needed functionality for this library, but as I needed it I'm squashing bulk of changed into this PR.

There were two bugs I faced.

1. When notification is shown and user is in a middle of interaction (panning) if timer fires event to close notification it's being flagged as `shouldSilent`. As user ends interaction panning notification to the bottom, notification is being dismissed (because of `shouldSilent`), but condition in completion block `if translation.y < -5` is not satisfied which results to notification not being removed from superview. Which then results to notification re-appearance when `func orientationDidChange()` is triggered (and it's being triggered if i.e going from background to foreground)

![a](https://user-images.githubusercontent.com/3721061/26865218-58e4c226-4b64-11e7-82ac-31af1b9756fb.gif)

2. `orientationDidChange` still does not have new frame on rotation on iPad. So I took advantage of `.flexibleWidth` for `backgroundView` and notification itself so that I could re-layout if needed in `layoutSubviews` method if it's being called due to rotation.

![b](https://user-images.githubusercontent.com/3721061/26865295-a9ca0516-4b64-11e7-8ec6-dbc5eb819c14.gif)

Even though in my project `orientationDidChange` got new superview frame, so that might be related to other things, but I could not figure out which ones.

If some functionality is not desired I can cherry pick thing and make another PR if needed.
Great lib btw!