### PR TITLE
Removed the Team Identifier from the demo project

### DIFF
--- a/Demo/WhisperDemo/WhisperDemo.xcodeproj/project.pbxproj
+++ b/Demo/WhisperDemo/WhisperDemo.xcodeproj/project.pbxproj
@@ -180,7 +180,6 @@
 					};
 					29AD42991BBC2BD2004292F1 = {
 						CreatedOnToolsVersion = 7.0;
-						DevelopmentTeam = LG4DBY4QF9;
 						LastSwiftMigration = 0800;
 						ProvisioningStyle = Automatic;
 					};
@@ -438,7 +437,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = LG4DBY4QF9;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = WhisperDemo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.WhisperDemo;
@@ -454,7 +453,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = LG4DBY4QF9;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = WhisperDemo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = no.hyper.WhisperDemo;


### PR DESCRIPTION
I've removed the Team Identifier inside the demo Xcode project.
It is unlikely that peoples that want to try the Whisper demo will be part of that checked out team and it is marked as an error by Xcode and it will not run the demo even on the Simulator until you remove it.