### PR TITLE
Fixing keyboard visibility bug in WhistleFactory

### DIFF
--- a/Source/WhistleFactory.swift
+++ b/Source/WhistleFactory.swift
@@ -139,7 +139,7 @@ open class WhistleFactory: UIViewController {
 
     let initialOrigin = whistleWindow.frame.origin.y
     whistleWindow.frame.origin.y = initialOrigin - titleLabelHeight
-    whistleWindow.makeKeyAndVisible()
+    whistleWindow.isHidden = false
     UIView.animate(withDuration: 0.2, animations: {
       self.whistleWindow.frame.origin.y = initialOrigin
     })
@@ -151,7 +151,7 @@ open class WhistleFactory: UIViewController {
       self.whistleWindow.frame.origin.y = finalOrigin
       }, completion: { _ in
         if let window = self.previousKeyWindow {
-          window.makeKeyAndVisible()
+          window.isHidden = false
           self.whistleWindow.windowLevel = UIWindowLevelNormal - 1
           self.previousKeyWindow = nil
           window.rootViewController?.setNeedsStatusBarAppearanceUpdate()


### PR DESCRIPTION
As detailed in https://stackoverflow.com/questions/15554481/keyboard-doesnt-come-up-with-multiple-uiwindows
using `makeKeyAndVisible()` causes the keyboard to dismiss. Prefer using `isHidden = false` instead to avoid this side-effect.

Further discussion: are there any side-effects of *not* using `makeKeyAndVisible()`?