### PR TITLE
Support both Swift 3/4 versions of text attributes

### DIFF
--- a/Source/WhistleFactory.swift
+++ b/Source/WhistleFactory.swift
@@ -99,13 +99,21 @@ open class WhistleFactory: UIViewController {
     let defaultHeight = titleLabelHeight
 
     if let text = titleLabel.text {
+      #if swift(>=4.0)
       let neededDimensions =
         NSString(string: text).boundingRect(
-          with: CGSize(width: labelWidth, height: CGFloat.infinity),
-          options: NSStringDrawingOptions.usesLineFragmentOrigin,
+          with: CGSize(width: labelWidth, height: .infinity),
+          options: .usesLineFragmentOrigin,
           attributes: [NSAttributedStringKey.font: titleLabel.font],
-          context: nil
-        )
+          context: nil)
+      #else
+      let neededDimensions =
+        NSString(string: text).boundingRect(
+          with: CGSize(width: labelWidth, height: .infinity),
+          options: .usesLineFragmentOrigin,
+          attributes: [NSFontAttributeName: titleLabel.font],
+          context: nil)
+      #endif
       titleLabelHeight = CGFloat(neededDimensions.size.height)
       titleLabel.numberOfLines = 0 // Allows unwrapping
 


### PR DESCRIPTION
Right now the source can only compile for swift4, so adding in support to still be backwards compatible with swift 3.2 which is still a valid language as of Xcode9. This can eventually be removed once it's no longer a supported language.