### PR TITLE
Accessibility & VoiceOver usability improvement

### DIFF
--- a/Source/ShoutFactory.swift
+++ b/Source/ShoutFactory.swift
@@ -143,7 +143,25 @@ open class ShoutView: UIView {
     frame.size.height = 0
     UIView.animate(withDuration: 0.35, animations: {
       self.frame.size.height = self.internalHeight + Dimensions.touchOffset
-    })
+    }) { _ in UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, self) }
+  }
+
+  // MARK: - Accessibility
+
+  open override func accessibilityPerformEscape() -> Bool {
+    self.silent()
+    
+    return true
+  }
+
+  open override var isAccessibilityElement: Bool {
+    get { return true }
+    set {}
+  }
+
+  open override var accessibilityLabel: String? {
+    get { return "\(titleLabel.text ?? ""): \(subtitleLabel.text ?? "")" }
+    set {}
   }
 
   // MARK: - Setup
@@ -203,6 +221,7 @@ open class ShoutView: UIView {
         self.completion?()
         self.displayTimer.invalidate()
         self.removeFromSuperview()
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, nil)
     })
   }
 

--- a/Source/WhisperFactory.swift
+++ b/Source/WhisperFactory.swift
@@ -117,7 +117,7 @@ class WhisperFactory: NSObject {
 
         subview.alpha = 1
       }
-    })
+    }) { _ in UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, self.whisperView) }
   }
 
   func showView() {
@@ -137,6 +137,7 @@ class WhisperFactory: NSObject {
       }, completion: { _ in
         self.delayTimer = Timer.scheduledTimer(timeInterval: 1.5, target: self,
           selector: #selector(WhisperFactory.delayFired(_:)), userInfo: nil, repeats: false)
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, self.whisperView)
     })
   }
 
@@ -155,6 +156,7 @@ class WhisperFactory: NSObject {
 
     presentTimer = Timer.scheduledTimer(timeInterval: AnimationTiming.movement * 1.1, target: self,
       selector: #selector(WhisperFactory.presentFired(_:)), userInfo: array, repeats: false)
+    UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, self.whisperView)
   }
 
   func hideView() {
@@ -168,6 +170,7 @@ class WhisperFactory: NSObject {
       }
       }, completion: { _ in
         self.whisperView.removeFromSuperview()
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, self.whisperView)
     })
   }
 

--- a/Source/WhistleFactory.swift
+++ b/Source/WhistleFactory.swift
@@ -162,7 +162,7 @@ open class WhistleFactory: UIViewController {
     whistleWindow.isHidden = false
     UIView.animate(withDuration: 0.2, animations: {
       self.whistleWindow.frame.origin.y = initialOrigin
-    })
+    }) { _ in UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, self.whistleWindow) }
   }
 
   public func hide() {
@@ -176,6 +176,7 @@ open class WhistleFactory: UIViewController {
           self.previousKeyWindow = nil
           window.rootViewController?.setNeedsStatusBarAppearanceUpdate()
         }
+        UIAccessibilityPostNotification(UIAccessibilityLayoutChangedNotification, self)
     })
   }
 


### PR DESCRIPTION
Thanks for library.

Since most of it is built on UIKit, it is accessible to VoiceOver (VO) by default. However, VO users aren't made aware of Shouts/Whistles/Whispers appearing and disappearing on screen.

This PR attempts to fix this issue by posting UIAccessibilityNotifications wherever necessary, so that VO can announce and play the corresponding sound effects when notifications are presented or dismissed.

Happy to make changes as necessary.